### PR TITLE
Allowing negative enum values

### DIFF
--- a/tools/parsers/cpp/src/CppParser.cpp
+++ b/tools/parsers/cpp/src/CppParser.cpp
@@ -1086,7 +1086,7 @@ public:
                 // read value
                 file.ignore();
                 skipWs();
-                readBefore(member.value, " ,}\r\n\t");
+                readBefore(member.value, " ,}/\r\n\t");
                 skipWsOnly();
                 if (!en.members.empty())
                     readDescrComment(en.members.back().description);

--- a/tools/parsers/cpp/src/CppParser.cpp
+++ b/tools/parsers/cpp/src/CppParser.cpp
@@ -1086,7 +1086,7 @@ public:
                 // read value
                 file.ignore();
                 skipWs();
-                readBefore(member.value);
+                readBefore(member.value, " ,}\r\n\t");
                 skipWsOnly();
                 if (!en.members.empty())
                     readDescrComment(en.members.back().description);


### PR DESCRIPTION
This fixes parsing of enum declarations using negative values, as in:

    enum MYENUM {
        first = -1,
        second
    };