### PR TITLE
Initializing port and host members of ClientHandler

### DIFF
--- a/core/server/src/ClientHandler.cpp
+++ b/core/server/src/ClientHandler.cpp
@@ -109,6 +109,8 @@ struct ClientContext
         poolBody(pooler->obtain(1024)),
         poolWrite(pooler->obtain(4096))
     {
+        host[0] = '\0';
+        port[0] = '\0';
         request.clientHost = host;
         request.clientPort = port;
         response.poolBody = poolWrite;
@@ -201,8 +203,6 @@ void ClientHandler::connected(Socket fd, const sockaddr_storage* addr)
                        << " (host=" << clientContext->host << ", port=" << clientContext->port << ")";
         } else {
             LogWarning() << "Failed to get client info: " << gai_strerror(res);
-            clientContext->host[0] = '\0';
-            clientContext->port[0] = '\0';
         }
     } else {
         LogError() << "Client #" << fd << " is already connected";


### PR DESCRIPTION
These two variable members were not  initialized, causing two warnings to be shown after running run_cppcheck script:

warning: Member variable 'ClientContext::host' is not initialized in the constructor.
warning: Member variable 'ClientContext::port' is not initialized in the constructor.

To fix that, the variables are now initialized in the constructor.
As a side effect, there is no need to initialize host and port to '\0' when client is already connected.