### PR TITLE
Trim MemPool chunks when recycle

### DIFF
--- a/core/utils/src/MemPool.cpp
+++ b/core/utils/src/MemPool.cpp
@@ -81,6 +81,17 @@ char* MemPool::putData(const char* data, uint64_t size)
     return reinterpret_cast<char*>(memcpy(grow(size), data, size));
 }
 
+void MemPool::trim()
+{
+    if (chunkIndex + 1 >= chunksCount)
+        return;
+
+    for (Chunk *curr = currChunk + 1; chunksCount > chunkIndex + 1; ++curr, --chunksCount) {
+        ::free(curr->buffer);
+        memset(curr, 0, sizeof(Chunk));
+    }
+}
+
 MemPool::Chunk* MemPool::flatten(bool terminate)
 {
     if (!chunksCount)

--- a/core/utils/src/MemPool.h
+++ b/core/utils/src/MemPool.h
@@ -268,6 +268,11 @@ public:
         return chunkSize;
     }
 
+    /**
+     * @brief remove chunks after currChunk
+     */
+    void trim();
+
 private:
     void newChunk(uint64_t size = NGREST_MEMPOOL_CHUNK_SIZE);
 

--- a/core/utils/src/MemPooler.cpp
+++ b/core/utils/src/MemPooler.cpp
@@ -75,9 +75,8 @@ void MemPooler::recycle(MemPool* pool)
     if (poolsByChunk.unused.size() >= MAX_POOLS_COUNT) {
         delete pool;
     } else {
-        // TODO: trim ?
-        // pool->trim();
         pool->reset();
+        pool->trim();
         poolsByChunk.unused.push_back(pool);
     }
 }


### PR DESCRIPTION
When a request needs more than one chunk and the next request needs
only one, the response of the second request comes with chunks of the
first one, because ngrest_server_write_response always writes all
chunks. This also prevents ngrest from holding several unused chunks.