### PR TITLE
enhancements for nginx module: hotdeploying, support for nonroot location in nginx configuration and error result from handler when initialization fail

### DIFF
--- a/core/engine/src/Deployment.h
+++ b/core/engine/src/Deployment.h
@@ -48,10 +48,10 @@ public:
     ~Deployment();
 
     /**
-     * @brief deploy all service libraries from path given
+     * @brief deploy all service libraries from path given, takes unchanged libs from oldDeployment
      * @param servicesPath path to directory where service libraries are placed
      */
-    void deployAll(const std::string& servicesPath);
+    void deployAll(const std::string& servicesPath, Deployment* oldDeployment);
 
     /**
      * @brief deploy one service from library

--- a/core/engine/src/Engine.cpp
+++ b/core/engine/src/Engine.cpp
@@ -26,6 +26,7 @@
 #include "ServiceDispatcher.h"
 #include "Transport.h"
 #include "Engine.h"
+#include "SnapShots.h"
 
 namespace ngrest {
 
@@ -64,6 +65,11 @@ public:
 Engine::Engine(ServiceDispatcher& serviceDispatcher_):
     serviceDispatcher(serviceDispatcher_)
 {
+}
+
+void Engine::setSnapShots(SnapShots* snapShots)
+{
+    this->snapShots = snapShots;
 }
 
 void Engine::setFilterDispatcher(FilterDispatcher* filterDispatcher)
@@ -110,6 +116,12 @@ ServiceDispatcher& Engine::getServiceDispatcher()
 FilterDispatcher* Engine::getFilterDispatcher()
 {
     return filterDispatcher;
+}
+
+void Engine::writeDeploymentInfo(MemPool* out)
+{
+    if (snapShots) snapShots->dumpHtml(out);
+    else out->putCString("<span class=\"nocontent\">Hot deployments unavailable</span>");
 }
 
 } // namespace ngrest

--- a/core/engine/src/Engine.h
+++ b/core/engine/src/Engine.h
@@ -21,6 +21,7 @@
 #ifndef NGREST_ENGINE_H
 #define NGREST_ENGINE_H
 
+#include "string"
 #include "ngrestengineexport.h"
 
 namespace ngrest {
@@ -29,6 +30,8 @@ enum class Phase;
 struct MessageContext;
 class ServiceDispatcher;
 class FilterDispatcher;
+class MemPool;
+class SnapShots;
 
 /**
  * @brief Message processing engine.
@@ -44,6 +47,12 @@ public:
      * @param serviceDispatcher service dispatcher to use
      */
     Engine(ServiceDispatcher& serviceDispatcher);
+
+    /**
+     * @brief set snapShots for status
+     * @param snapShots for status
+     */
+    void setSnapShots(SnapShots* snapShots);
 
     /**
      * @brief set filter dispatcher for engine
@@ -76,9 +85,16 @@ public:
      */
     FilterDispatcher* getFilterDispatcher();
 
+    /**
+     * @brief write deployment info as html table to ostream
+     * @return deployment info
+     */
+    void writeDeploymentInfo(MemPool*);
+
 private:
     ServiceDispatcher& serviceDispatcher;
     FilterDispatcher* filterDispatcher = nullptr;
+    SnapShots* snapShots = nullptr;
 };
 
 } // namespace ngrest

--- a/core/engine/src/FilterDeployment.h
+++ b/core/engine/src/FilterDeployment.h
@@ -51,7 +51,7 @@ public:
      * @brief deploy all filter libraries from path given
      * @param filtersPath path to directory where filter libraries are placed
      */
-    void deployAll(const std::string& filtersPath);
+    void deployAll(const std::string& filtersPath, FilterDeployment* oldDeployment);
 
     /**
      * @brief deploy one filter from library

--- a/core/engine/src/LatestLibs.h
+++ b/core/engine/src/LatestLibs.h
@@ -1,0 +1,83 @@
+/*
+ *  Copyright 2017 NAM system, a.s.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef NGREST_LATESTLIBS_H
+#define NGREST_LATESTLIBS_H
+
+#include <string.h>
+#include <unordered_map>
+
+#include <ngrest/utils/File.h>
+#include "LatestLibs.h"
+
+namespace ngrest {
+
+/**
+ * @brief List of libraries with one item for all numbers in form of "filename.so.number". List is filtered by extension NGREST_LIBRARY_EXT, which must be either suffix or just before version number.
+ */
+class LatestLibs {
+public:
+    /**
+     * @brief Item in map containg original filename and version from suffix.
+     */
+    struct Version {
+        std::string filename;
+        int version;
+    };
+
+    /**
+     * @brief Map of latest libraries. Key is filename with version number removed, value has full filename.
+     */
+    std::unordered_map<std::string, Version> map;
+
+    /**
+     * @brief Constructor takes full list of files and put unique filename with highest version into map. During input list iteration versions are compared with filenames read so far.
+     * @param allLibs list of files in libraries directory
+     */
+    LatestLibs(const StringList& allLibs) {
+        const size_t extlen = strlen(NGREST_LIBRARY_EXT);
+
+        for (const std::string& lib : allLibs) {
+            size_t len = lib.length();
+            if (len > extlen) {
+                if (lib.compare(len - extlen, extlen, NGREST_LIBRARY_EXT) == 0) {
+                    map[lib] = { lib, 0 };
+                }
+                else {
+                    size_t pos = lib.find_last_of('.');
+                    if (pos != std::string::npos && pos > extlen) {
+                        const char* lastdot = lib.c_str() + pos;
+                        if (!strncmp(lastdot - extlen, NGREST_LIBRARY_EXT, extlen)) {
+                            char* endptr;
+                            int version = strtol(lastdot + 1, &endptr, 10);
+                            if (!*endptr) {
+                                Version& v = map[lib.substr(0, pos)];
+                                if (v.version <= version) {
+                                    v.version = version;
+                                    v.filename = lib;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+} // namespace ngrest
+
+#endif // NGREST_LATESTLIBS_H

--- a/core/engine/src/SnapShots.cpp
+++ b/core/engine/src/SnapShots.cpp
@@ -1,0 +1,161 @@
+/*
+ *  Copyright 2017 NAM system, a.s.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include "SnapShots.h"
+#include <ngrest/utils/Exception.h>
+#include <ngrest/utils/MemPool.h>
+#include <errno.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifdef WIN32
+#define stat _stat
+#endif
+
+namespace ngrest {
+
+static const int POLL_INTERVAL = 1; // min period between deployments
+
+static time_t timeModified(const std::string& path)
+{
+    struct stat attr;
+    int err = stat(path.c_str(), &attr);
+    NGREST_ASSERT(err == 0, std::string("Failed to read directory ") + strerror(errno) + " " + path);
+    return attr.st_mtime;
+}
+
+SnapShot::SnapShot(const std::string& servicesPath, const std::string& filtersPath,
+    time_t timeServices, time_t timeFilters, SnapShot* oldSnapShot, SnapShots* snapShots) :
+    deployment(dispatcher), filterDeployment(filterDispatcher), engine(dispatcher)
+{
+	engine.setSnapShots(snapShots);
+    deployment.deployAll(servicesPath, oldSnapShot ? &oldSnapShot->deployment : 0);
+
+    if (!filtersPath.empty()) {
+        engine.setFilterDispatcher(&filterDispatcher);
+        filterDeployment.deployAll(filtersPath, oldSnapShot ? &oldSnapShot->filterDeployment : 0);
+    }
+
+    this->timeServices = timeServices;
+    this->timeFilters = timeFilters;
+}
+
+SnapShot::~SnapShot()
+{
+    deployment.undeployAll();
+    filterDeployment.undeployAll();
+}
+
+SnapShots::Ref SnapShots::latest()
+{
+    pollDeploy();
+    for (int i=0; i<10*LIMIT; i++) {
+        int version = this->version;
+        Ref ref(slots[version % LIMIT]);
+        if (ref.slot.version == version) return ref;
+    }
+    NGREST_THROW_ASSERT("Failed to lock snapshot");
+}
+
+void SnapShots::pollDeploy()
+{
+    time_t now = time(0);
+    time_t last = timePoll;
+    if (last > now || !timePoll.compare_exchange_weak(last, now + POLL_INTERVAL)) return;
+
+    std::lock_guard<std::mutex> guard(deployMutex);
+
+    int prevVersion = version;
+    for (; oldestVersion < prevVersion; oldestVersion++) {
+        Slot& slot = slots[oldestVersion % LIMIT];
+        if (slot.snapShot) {
+			if (slot.refs > 0) break;
+            delete slot.snapShot;
+            slot.snapShot = 0;
+        }
+    }
+
+    int newVersion = prevVersion + 1;
+    Slot& slot = slots[newVersion % LIMIT];
+    if (slot.snapShot) return; // no room
+
+    time_t timeServices = timeModified(servicesPath);
+    time_t timeFilters = filtersPath.empty() ? 0 : timeModified(filtersPath);
+
+    if (timeDeployedServices < timeServices ||
+        timeDeployedFilters < timeFilters) {
+
+        SnapShot* oldSnapShot = slots[newVersion % LIMIT].snapShot;
+        slot.snapShot = new SnapShot(servicesPath, filtersPath, timeServices, timeFilters, oldSnapShot, this);
+        slot.version = newVersion;
+
+        timeDeployedServices = timeServices;
+        timeDeployedFilters = timeFilters;
+        version = newVersion;
+    }
+}
+
+void SnapShots::undeployAll()
+{
+    std::lock_guard<std::mutex> guard(deployMutex);
+    for (Slot& slot : slots) {
+        if (slot.refs == 0 && slot.snapShot) {
+            delete slot.snapShot;
+            slot.snapShot = 0;
+        }
+    }
+}
+
+static char* printLong(char* out, long val)
+{
+	sprintf(out, "%ld", val);
+	return out;
+}
+
+template<size_t n> char* printTime(char (&out) [n], time_t time)
+{
+	if (!time) *out = 0;
+	else strftime(out, n, "%F %T", localtime(&time));
+	return out;
+}
+
+void SnapShots::dumpHtml(MemPool* out)
+{
+	char buff[30];
+    std::lock_guard<std::mutex> guard(deployMutex);
+    out->putCString("<table border=1><tr>"
+        "<td>#</td>"
+        "<td>Service Time</td>"
+        "<td>Filter Time</td>"
+        "</tr>");
+    for (int i=version; i>=oldestVersion; i--) {
+        Slot& slot = slots[i % LIMIT];
+        SnapShot* shot = slot.snapShot;
+        if (shot) {
+			out->putCString("<tr><td>");
+			out->putCString(printLong(buff, slot.version));
+			out->putCString("</td><td>");
+			out->putCString(printTime(buff, shot->timeServices));
+			out->putCString("</td><td>");
+			out->putCString(printTime(buff, shot->timeFilters));
+			out->putCString("</td></tr>");
+        }
+    }
+	out->putCString("</table>");
+}
+
+} // namespace ngrest

--- a/core/engine/src/SnapShots.h
+++ b/core/engine/src/SnapShots.h
@@ -1,0 +1,156 @@
+/*
+ *  Copyright 2017 NAM system, a.s.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef NGREST_SNAPSHOTS_H
+#define NGREST_SNAPSHOTS_H
+
+#include <atomic>
+#include <mutex>
+#include "Engine.h"
+#include "FilterDispatcher.h"
+#include "FilterDeployment.h"
+#include "ServiceDispatcher.h"
+#include "Deployment.h"
+
+namespace ngrest {
+
+/**
+ * @brief snapshot of deployment, contains objects that where originally singletons in modules/share/ngrest_server.cpp.
+ */
+class SnapShot {
+public:
+    SnapShot(const std::string& servicesPath, const std::string& filtersPath, time_t timeServices, time_t timeFilters, SnapShot* oldSnapShot, class SnapShots* snapShots);
+    ~SnapShot();
+
+    ngrest::ServiceDispatcher dispatcher;
+    ngrest::Deployment deployment;
+    ngrest::FilterDispatcher filterDispatcher;
+    ngrest::FilterDeployment filterDeployment;
+    ngrest::Engine engine;
+    time_t timeServices; // directory modify time, just for serverstatus
+    time_t timeFilters;
+};
+
+/**
+ * @brief all snapshots of deployments
+ */
+class SnapShots {
+
+    /**
+     * @brief Slot structure is ment to deal with dangling SnapShot pointer. Slot is permanent to allow lockfree reading. Concurrent write is detected by comparing version before and after read. If 'refs' is increased without detecting version change, pointer is safe.
+     */
+    struct Slot {
+        /**
+         * @brief snapShot contained in slot
+         */
+        SnapShot* volatile snapShot;
+        /**
+         * @brief version of snapShot
+         */
+        long volatile version;
+        /**
+         * @brief number of references (Ref instances) to this slot
+         */
+        std::atomic<int> refs;
+    };
+
+    /**
+     * @brief reference to Slot, modifies counter in Slot in RAII manner
+     */
+    class Ref {
+    public:
+        Slot& slot;
+        Ref(Slot& _slot) : slot(_slot) { slot.refs++; }
+        Ref(const Ref& src) : slot(src.slot) { slot.refs++; }
+        ~Ref() { slot.refs--; }
+    };
+
+
+    /**
+     * @brief max snapshots at once
+     */
+    static const int LIMIT = 8;
+
+    /**
+     * @brief reference to Slot, modifies counter in Slot in RAII manner
+     */
+    Slot slots[LIMIT] = {};
+
+    /**
+     * @brief for cleaning unused snapshots
+     */
+    int oldestVersion {};
+
+    /**
+     * @brief latest version, chooses slot for new request
+     */
+    std::atomic<int> version {};
+
+    /**
+     * @brief last time when directory change was polled
+     */
+    std::atomic<time_t> timePoll {};
+
+    /**
+     * @brief only one thread can make new snapshot or make cleaning
+     */
+    std::mutex deployMutex;
+
+    /**
+     * @brief services directory modify time at time of deployment
+     */
+    time_t timeDeployedServices;
+
+    /**
+     * @brief filters directory modify time at time of deployment
+     */
+    time_t timeDeployedFilters;
+
+public:
+    /**
+     * @brief directory to search for services
+     */
+    std::string servicesPath;
+
+    /**
+     * @brief directory to search for filters
+     */
+    std::string filtersPath;
+
+    /**
+     * @brief return latest deployment snapshot
+     */
+    Ref latest();
+
+    /**
+     * @brief poll for directory changs and deploy new snapshot
+     */
+    void pollDeploy();
+
+    /**
+     * @brief undeploy all snapshots
+     */
+    void undeployAll();
+
+    /**
+     * @brief dump as html table
+     */
+    void dumpHtml(class MemPool* out);
+};
+
+}
+
+#endif

--- a/core/server/src/main.cpp
+++ b/core/server/src/main.cpp
@@ -93,15 +93,15 @@ int main(int argc, char* argv[])
 
     const std::string& filtersPath = ngrest::Runtime::getSharePath()
         + NGREST_PATH_SEPARATOR "filters" NGREST_PATH_SEPARATOR;
-    filterDeployment.deployAll(filtersPath);
+    filterDeployment.deployAll(filtersPath, nullptr);
 
     const std::string& servicesPath = ngrest::Runtime::getSharePath()
         + NGREST_PATH_SEPARATOR "services" NGREST_PATH_SEPARATOR;
-    deployment.deployAll(servicesPath);
+    deployment.deployAll(servicesPath, nullptr);
 
     auto itPath = args.find("s");
     if (itPath != args.end())
-        deployment.deployAll(itPath->second + NGREST_PATH_SEPARATOR);
+        deployment.deployAll(itPath->second + NGREST_PATH_SEPARATOR, nullptr);
 
     ngrest::LogInfo() << "Server startup time: " << (timer.elapsed() / 1000.) << "ms";
 

--- a/core/utils/src/DynamicLibrary.cpp
+++ b/core/utils/src/DynamicLibrary.cpp
@@ -31,10 +31,21 @@ namespace ngrest {
 
 DynamicLibrary::DynamicLibrary()
 {
+    handle = nullptr;
 }
 
 DynamicLibrary::~DynamicLibrary()
 {
+    if (handle) unload();
+}
+
+DynamicLibrary& DynamicLibrary::operator=(DynamicLibrary&& src)
+{
+    libName = std::move(src.libName);
+    raw = src.raw;
+    handle = src.handle;
+    src.handle = nullptr;
+    return *this;
 }
 
 void DynamicLibrary::load(const std::string& libName, bool raw /*= false*/)

--- a/core/utils/src/DynamicLibrary.h
+++ b/core/utils/src/DynamicLibrary.h
@@ -56,6 +56,11 @@ public:
     virtual ~DynamicLibrary();
 
     /**
+     * @brief move assigment
+     */
+    DynamicLibrary& operator=(DynamicLibrary&& src);
+
+    /**
      * @brief load dynamic library
      * @param libName library name
      * @param raw if true libName contains full path to library

--- a/core/utils/src/Plugin.h
+++ b/core/utils/src/Plugin.h
@@ -34,6 +34,13 @@ template <typename PluginType>
 class Plugin: public DynamicLibrary
 {
 public:
+    Plugin& operator=(Plugin&& src)
+    {
+        DynamicLibrary::operator=(std::move(src));
+        pluginSymbol = src.pluginSymbol;
+        return *this;
+    }
+
     /**
      * @brief load shared library by given path
      * @param path path to shared library

--- a/services/serverstatus/src/ServerStatus.h
+++ b/services/serverstatus/src/ServerStatus.h
@@ -32,6 +32,9 @@ namespace ngrest {
 class ServerStatus: public Service
 {
 public:
+    // *location: deployments
+    void getDeployments(MessageContext& context);
+
     // *location: filters
     void getFilters(MessageContext& context);
 


### PR DESCRIPTION
# Hot Deploying
Before a http request plugin polls for service directory modifications and loads new libraries. Poll intervals are limited to one per second. Old version is held til it is used in any other thread. Because multiple versions lifetime can overlap a and system caches libraries by name, new versions must have a different name. Versions are distinguished by numeric suffix and plugin only loads library with highest suffix.

Singleton objects deployment and dispatchers from ngrest_server.cpp are now enclosed in SnapShot class which instances are being held in SnapShots class. SnapShots use in threads are reference counted with RAII SnapShots::Ref class.

Any thread can make new snapshots and delete all in http request handler. These updates are synchronized by STL mutex. To decrease overhead, updates are limited to one per second by atomic compare and exchange SnapShots::pollTime variable with present time in seconds. This atomic operation only allows single thread to write new time and other threads simply skip updating. Mutex is just a failsafe and its overhead without collision should be as low as few atomic operations if it is implemented with of pthread_mutex or EnterCriticalSection.

# Location
I have this configuration to allow nginx to handle static content:
```
        location ~ /rest/ {
                ngrest /usr/share/ngrest/services;
        }
```
Modified mod_ngrest_nginx.c stores "root" path prefix during initialization and removes it from URIs passed to dispatcher. Serverstatus is also modified to use mostly relative paths to support above cfg and maybe request beyond proxy.

# Result Code
Nginx plugin initialization is moved from mod_ngrest_handler() to mod_ngrest_request_handler(), where result code can be returned. Now it happens before calling ngx_http_read_client_request_body(). If initilization fails, NGX_HTTP_INTERNAL_SERVER_ERROR is returned instead of NGX_OK. For some reason my browser waited indefinitely if initilization failed and handler returned NGX_OK. Maybe it is a bug in Nginx.